### PR TITLE
implemented and tested ValidationException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ before_script:
     - composer self-update
     - composer install
 
-script: phpunit
+script: vendor/bin/phpunit

--- a/Controller.php
+++ b/Controller.php
@@ -71,8 +71,6 @@ class Controller extends BaseController
      **/
     protected function validate($obj)
     {
-        throw new \RuntimeException('Not yet implemented.');
-
         $errors = $this->container->get('validator')->validate($obj);
 
         if (count($errors) > 0) {

--- a/Exception/ServiceException.php
+++ b/Exception/ServiceException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AC\WebServicesBundle\Exception;
+
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+/**
+ * Base class for all service exceptions.  They can provide a data structure
+ * that will be intercepted and serialized by the serializer.
+ */
+class ServiceException extends HttpException
+{
+    private $data;
+
+    public function __construct($code, $data, $message = null)
+    {
+        $this->data = $data;
+
+        parent::__construct($code, $message);
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+}

--- a/Exception/ValidationException.php
+++ b/Exception/ValidationException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AC\WebServicesBundle\Exception;
+
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+class ValidationException extends ServiceException
+{
+    public function __construct(ConstraintViolationListInterface $errors, $message = null)
+    {
+        $data = [];
+
+        // assemble all
+        foreach ($errors as $error) {
+            $path = $error->getPropertyPath();
+
+            if (!isset($data[$path])) {
+                $data[$path] = [
+                    'path' => $path,
+                    'messages' => []
+                ];
+            }
+
+            $data[$path]['messages'][] = $error->getMessage();
+        }
+
+        parent::__construct(422, ['errors' => array_values($data)], $message);
+    }
+}

--- a/Tests/Fixtures/App/config.yml
+++ b/Tests/Fixtures/App/config.yml
@@ -8,6 +8,7 @@ framework:
     translator:      { fallback: en }
     profiler:        { only_exceptions: false }
     test: ~
+    validation: { enable_annotations: true }
     templating:
         cache: ~
         engines: [twig]

--- a/Tests/Fixtures/FixtureBundle/Controllers.php
+++ b/Tests/Fixtures/FixtureBundle/Controllers.php
@@ -14,6 +14,8 @@ use AC\WebServicesBundle\Tests\Fixtures\FixtureBundle\Model\Person;
 use AC\WebServicesBundle\Tests\Fixtures\FixtureBundle\Model\Group;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\DeserializationContext;
+use AC\WebServicesBundle\Exception\ServiceException;
+use AC\WebServicesBundle\Exception\ValidationException;
 
 /**
  * These controller routes are called by various tests to ensure any API responds as expected based
@@ -141,5 +143,31 @@ class Controllers extends Controller
         $data = $this->decodeRequest('AC\WebServicesBundle\Tests\Fixtures\FixtureBundle\Model\Person');
 
         return new ServiceResponse(array('person' => $data));
+    }
+
+    /**
+     * @Route("/api/service-exception")
+     * @Method("GET")
+     */
+    public function apiServiceException()
+    {
+        throw new ServiceException(422, ['foo' => 'bar']);
+    }
+
+    /**
+     * @Route("/api/validation-exception")
+     * @Method("GET")
+     */
+    public function apiValidationException()
+    {
+        $group = new Group('foo', 'blahblahblah');
+        $group->setOwner(new Person('John', 3));
+        $group->setMembers([
+            new Person('Foobert', 1),
+            new Person("33", 2),
+            new Person('Barbara', 3)
+        ]);
+
+        $this->validate($group);
     }
 }

--- a/Tests/Fixtures/FixtureBundle/Model/Group.php
+++ b/Tests/Fixtures/FixtureBundle/Model/Group.php
@@ -3,13 +3,21 @@
 namespace AC\WebServicesBundle\Tests\Fixtures\FixtureBundle\Model;
 
 use JMS\Serializer\Annotation as JMS;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class Group
 {
+    public function __construct($id = null, $name = null)
+    {
+        $this->id = $id;
+        $this->name = $name;
+    }
+
     /**
      * @JMS\Type("integer")
      * @JMS\ReadOnly
      * @JMS\SerializedName("id")
+     * @Assert\Type("integer")
      **/
     protected $id;
     public function getId() { return $this->id; }
@@ -17,6 +25,8 @@ class Group
     /**
      * @JMS\Type("string")
      * @JMS\SerializedName("name")
+     * @Assert\Type("string")
+     * @Assert\Length(max=4)
      **/
     protected $name;
     public function getName() { return $this->name; }
@@ -25,6 +35,7 @@ class Group
     /**
      * @JMS\Type("AC\WebservicesBundle\Tests\Fixtures\FixtureBundle\Model\Person")
      * @JMS\SerializedName("owner")
+     * @Assert\Valid
      **/
     protected $owner;
     public function setOwner($owner) {$this->owner = $owner;}
@@ -33,6 +44,7 @@ class Group
     /**
      * @JMS\Type("array<AC\WebservicesBundle\Tests\Fixtures\FixtureBundle\Model\Person>")
      * @JMS\SerializedName("members")
+     * @Assert\Valid(traverse=true)
      **/
     protected $members;
     public function setMembers($members) {$this->members = $members;}

--- a/Tests/Fixtures/FixtureBundle/Model/Person.php
+++ b/Tests/Fixtures/FixtureBundle/Model/Person.php
@@ -3,6 +3,7 @@
 namespace AC\WebServicesBundle\Tests\Fixtures\FixtureBundle\Model;
 
 use JMS\Serializer\Annotation as JMS;
+use Symfony\Component\Validator\Constraints as Assert;
 
 class Person
 {
@@ -17,6 +18,7 @@ class Person
      * @JMS\Type("integer")
      * @JMS\ReadOnly
      * @JMS\SerializedName("id")
+     * @Assert\Type("integer")
      **/
     protected $id;
     public function getId() { return $this->id; }
@@ -32,6 +34,10 @@ class Person
     /**
      * @JMS\Type("string")
      * @JMS\Groups({"overview"})
+     * @Assert\Regex(pattern="/\d/", match=false, message="Your name cannot contain a number")
+     * @Assert\Type("string")
+     * @Assert\NotBlank
+     * @Assert\Length(min=4)
      **/
     protected $name;
     public function getName() { return $this->name; }
@@ -39,6 +45,7 @@ class Person
 
     /**
      * @JMS\Type("integer")
+     * @Assert\Type("integer")
      **/
     public $age;
     public function getAge() { return $this->age; }
@@ -47,6 +54,7 @@ class Person
     /**
      * @JMS\Type("AC\WebservicesBundle\Tests\Fixtures\FixtureBundle\Model\Person")
      * @JMS\SerializedName("bestFriend")
+     * @Assert\Valid
      **/
     protected $bestFriend;
     public function setBestFriend($bestFriend) {$this->bestFriend = $bestFriend;}
@@ -55,6 +63,7 @@ class Person
     /**
      * @JMS\Type("array<AC\WebservicesBundle\Tests\Fixtures\FixtureBundle\Model\Person>")
      * @JMS\SerializedName("otherFriends")
+     * @Assert\Valid(traverse=true)
      **/
     protected $otherFriends;
     public function setOtherFriends($otherFriends) {$this->otherFriends = $otherFriends;}

--- a/Tests/ServiceExceptionTest.php
+++ b/Tests/ServiceExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use AC\WebServicesBundle\TestCase;
+
+class ServiceExceptionTest extends TestCase
+{
+    public function testServiceException()
+    {
+        $result = $this->callJsonApi('GET', '/api/service-exception', ['expectedCode' => 422]);
+        $this->assertSame(422, $result['response']['code']);
+        $this->assertSame('bar', $result['foo']);
+    }
+
+    public function testValidationException()
+    {
+        $result = $this->callJsonApi('GET', '/api/validation-exception', ['expectedCode' => 422]);
+        $this->assertTrue(isset($result['errors']));
+        $this->assertSame('members[1].name', $result['errors'][2]['path']);
+        $this->assertTrue(2 === count($result['errors'][2]['messages']));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "require-dev": {
         "symfony/symfony": "~2.2",
         "symfony/monolog-bundle": "~2.2",
-        "sensio/framework-extra-bundle": "~2.2"
+        "sensio/framework-extra-bundle": "~2.2",
+        "phpunit/phpunit": "~4.0"
     },
     "conflict": {
         "jms/serializer": "<0.15",


### PR DESCRIPTION
Closes #3 

Provides a base exception that the api listener will serialize data structures from, if present.

Provides a ValidationException that formats the error output as described in the referenced issue.

Example response structure:

```
{
  "response": {
    "code": 422,
    "message": "Validation failed."
  },
  "errors": [
    {
      "path": "resource.client.id",
      "messages": [
        "This field is required",
        "This field should be a string"
      ]
    },
    {
      "path": "resource.type",
      "messages": [
        "[foo] is an invalid type.",
      ]
    }
  ]
}
```